### PR TITLE
Update docker build for buster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,8 @@ COPY docker/datadog-agent /etc/datadog-agent
 COPY docker/supervisord-datadog.conf /etc/supervisor/conf.d/supervisord-datadog.conf
 COPY docker/docker-entrypoint.sh /
 
-RUN apt-get install -y -q libjemalloc1=3.6.0-9.1
-ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.1
+# https://www.speedshop.co/2017/12/04/malloc-doubles-ruby-memory.html - limit malloc arenas
+ENV MALLOC_ARENA_MAX=4
 
 COPY Gemfile Gemfile.lock ./
 

--- a/Gemfile
+++ b/Gemfile
@@ -15,9 +15,6 @@ gem "turbolinks", "~> 5"
 # gem "jbuilder", "~> 2.7"
 # gem 'redis', '~> 4.0'
 
-# Use Active Storage variant
-# gem 'image_processing', '~> 1.2'
-
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", ">= 1.4.2", require: false
 


### PR DESCRIPTION
pulled from https://github.com/CruGlobal/missionhub-api/pull/1509

> This PR is for when the new docker base image drops. One of the concerns is that it upgrades to debian buster, which only have jemalloc 5 in the package registry. jemalloc 5 is know to not help ruby as much as 3.6, so I changed to MALLOC_ARENA_MAX instead.
medium.com/@andresakata/benchmark-of-memory-allocators-on-a-multi-threaded-ruby-program-354ec4dc2e7e